### PR TITLE
feat(submit-queue): add status validation

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -1057,8 +1057,6 @@ func (sq *SubmitQueue) validForMergeExt(obj *github.MungeObject, checkStatus boo
 	gateCLA := sq.GateCLA
 	gateApproved := sq.GateApproved
 	doNotMergeMilestones := sq.DoNotMergeMilestones
-	mergeContexts := mungeopts.RequiredContexts.Merge
-	retestContexts := mungeopts.RequiredContexts.Retest
 	additionalLabels := sq.AdditionalRequiredLabels
 	blockingLabels := sq.BlockingLabels
 	claYesLabels := sq.ClaYesLabels
@@ -1101,17 +1099,10 @@ func (sq *SubmitQueue) validForMergeExt(obj *github.MungeObject, checkStatus boo
 
 	// Validate the status information for this PR
 	if checkStatus {
-		if len(mergeContexts) > 0 {
-			if success, ok := obj.IsStatusSuccess(mergeContexts); !ok || !success {
-				sq.setContextFailedStatus(obj, mergeContexts)
-				return false
-			}
-		}
-		if len(retestContexts) > 0 {
-			if success, ok := obj.IsStatusSuccess(retestContexts); !ok || !success {
-				sq.setContextFailedStatus(obj, retestContexts)
-				return false
-			}
+		// Validate all statues except submit-queue
+		if success, ok := obj.IsStatusSuccessExceptSpecifiedContexts([]string{sqContext}); !ok || !success {
+			sq.SetMergeStatus(obj, ciFailure)
+			return false
 		}
 	}
 


### PR DESCRIPTION
check github CI statues except for submit-queue.
the origin submit-queue needs to specify the contexts to check, every repo can be different
