### PR TITLE
chore(*): delete deprecated comment

### DIFF
--- a/prow/plugins/lifecycle/lifecycle.go
+++ b/prow/plugins/lifecycle/lifecycle.go
@@ -17,7 +17,6 @@ limitations under the License.
 package lifecycle
 
 import (
-	"fmt"
 	"regexp"
 	"time"
 
@@ -79,13 +78,7 @@ type lifecycleClient interface {
 }
 
 func deprecate(gc commentClient, plugin, org, repo string, number int, e *github.GenericCommentEvent) error {
-	select {
-	case <-deprecatedTick:
-		// Only warn once per tick
-		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, fmt.Sprintf("The %s prow plugin is deprecated, please migrate to the lifecycle plugin before April 2018", plugin)))
-	default:
-		return nil
-	}
+	return nil
 }
 
 func lifecycleHandleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {


### PR DESCRIPTION
Remove:
```
The close prow plugin is deprecated, please migrate to the lifecycle plugin before April 2018

In response to this:

/close

Instructions for interacting with me using PR comments are available here. If you have questions or suggestions related to my behavior, please file an issue against the kubernetes/test-infra repository.```