### PR TITLE
chore(*): update retry policy

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -71,10 +71,10 @@ type Client struct {
 }
 
 const (
-	maxRetries    = 8
-	max404Retries = 2
-	maxSleepTime  = 2 * time.Minute
-	initialDelay  = 2 * time.Second
+	maxRetries    = 10
+	max404Retries = 4
+	maxSleepTime  = 5 * time.Minute
+	initialDelay  = 1 * time.Second
 )
 
 // Interface for how prow interacts with the http client, which we may throttle.


### PR DESCRIPTION
改了重试的次数，时间间隔等，先观察一段时间，不合

error log may be

```
{"author":"caosm","component":"hook","error":"sleep time for token reset exceeds max sleep time (8m29.866279172s \u003e 2m0s)","event-GUID":"68351210-8634-11e8-88bb-4d527ad814d6","event-type":"issue_comment","level":"error","msg":"Failed to get issue labels.","org":"caicloud","plugin":"help","pr":4415,"repo":"engineering","time":"2018-07-13T00:33:49Z","url":"https://github.com/caicloud/engineering/issues/4415#issuecomment-404357847"}
```