### PR TITLE
fix(label): strip markdown comments from label matcher

### DIFF
--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -351,6 +351,39 @@ func TestLabel(t *testing.T) {
 			expectedRemovedLabels: formatLabels("area/ruby", "kind/srv", "priority/l", "priority/m"),
 			commenter:             orgMember,
 		},
+		{
+			name: "Strip markdown comments",
+			body: `
+<!--
+/kind bug
+/kind cleanup
+-->
+/area infra
+`,
+			repoLabels:            []string{"area/infra"},
+			issueLabels:           []string{},
+			expectedNewLabels:     formatLabels("area/infra"),
+			expectedRemovedLabels: []string{},
+			commenter:             orgMember,
+		},
+		{
+			name: "Strip markdown comments non greedy",
+			body: `
+<!--
+/kind bug
+-->
+/kind cleanup
+<!--
+/area infra
+-->
+/kind regression
+`,
+			repoLabels:            []string{"kind/cleanup", "kind/regression"},
+			issueLabels:           []string{},
+			expectedNewLabels:     formatLabels("kind/cleanup", "kind/regression"),
+			expectedRemovedLabels: []string{},
+			commenter:             orgMember,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Right now we have to prefix the labels with something (like with `> ` in
k/k) to not apply a label. With this patch we can comment them out but
still preserve their formatting, which makes enabling labels much
easier. For example:

```markdown
<!-- Choose a kind:
/kind bug
-->
```

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #

**Special notes for your reviewer**:

/cc @bbbmj 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
